### PR TITLE
Make GitHub detect *.vf as Forth.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.vf linguist-language=Forth


### PR DESCRIPTION
 Hello,

Please merge this, if you'd like GitHub to detect your `.vf` files as Forth.

Thank you!
